### PR TITLE
feat: Add support for pronoundb for pronouns source.

### DIFF
--- a/src/components/messages/ChatMessage.vue
+++ b/src/components/messages/ChatMessage.vue
@@ -57,7 +57,9 @@
 				data-tooltip="Number of times this message has been sent"
 				v-if="messageData.occurrenceCount > 0">x{{messageData.occurrenceCount+1}}</div>
 			
-			<span class="pronoun" v-if="pronoun && $store.state.params.features.showUserPronouns.value===true">{{pronoun}}</span>
+			<span class="pronoun"
+				:data-tooltip="pronounLabel"
+				v-if="pronoun && $store.state.params.features.showUserPronouns.value===true">{{pronoun}}</span>
 			
 			<span @click.stop="openUserCard()"
 				@mouseenter="hoverNickName($event)"
@@ -116,6 +118,7 @@ export default class ChatMessage extends Vue {
 		const key = store.state.userPronouns[this.messageData.tags['user-id'] as string];
 		if(!key) return null;
 		const hashmap:{[key:string]:string} = {
+			// https://pronouns.alejo.io
 			"aeaer" : "Ae/Aer",
 			"any" : "Any",
 			"eem" : "E/Em",
@@ -132,9 +135,39 @@ export default class ChatMessage extends Vue {
 			"vever" : "Ve/Ver",
 			"xexem" : "Xe/Xem",
 			"ziehir" : "Zie/Hir",
+			// https://pronoundb.org
+			"hh": "he/him",
+			"hi": "he/it",
+			"hs": "he/she",
+			"ih": "it/him",
+			"ii": "it/its",
+			"is": "it/she",
+			"shh": "she/he",
+			"sh": "she/her",
+			"si": "she/it",
+			"st": "she/they",
+			"th": "they/he",
+			"ti": "they/it",
+			"ts": "they/she",
+			"tt": "they/them",
 		};
 		const res = hashmap[key];
 		return res? res : key;
+	}
+
+	public get pronounLabel(): string | null {
+		const key = store.state.userPronouns[this.messageData.tags['user-id'] as string];
+		if(!key) return null;
+
+		const hashmap: {[key: string]: string} = {
+			// https://pronoundb.org
+			"any": "Any pronouns",
+			"other": "Other pronouns",
+			"ask": "Ask me my pronouns",
+			"avoid": "Avoid pronouns, use my name",
+		};
+
+		return hashmap[key];
 	}
 
 	public get isAnnouncement():boolean {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -208,7 +208,7 @@ export default createStore({
 				keepHighlightMyMessages:	{save:true, type:"toggle", value:false, label:"Show \"highlight my message\" rewards in activity feed", id:210, icon:"notification_purple.svg"},
 				notifyJoinLeave:			{save:true, type:"toggle", value:false, label:"Notify when a user enters/leaves the chat", id:211, icon:"notification_purple.svg"},
 				stopStreamOnRaid:			{save:true, type:"toggle", value:false, label:"Cut OBS stream after a raid", id:212, icon:"obs_purple.svg"},
-				showUserPronouns:			{save:true, type:"toggle", value:false, label:"Show user pronouns (based on <a href='https://pronouns.alejo.io' target='_blank'>https://pronouns.alejo.io</a>)", id:213, icon:"user_purple.svg"},
+				showUserPronouns:			{save:true, type:"toggle", value:false, label:"Show user pronouns (based on <a href='https://pronouns.alejo.io' target='_blank'>https://pronouns.alejo.io</a> and <a href='https://pronoundb.org/' target='_blank'>PronounDB</a>')", id:213, icon:"user_purple.svg"},
 			} as {[key:string]:ParameterData}
 		} as IParameterCategory,
 		roomStatusParams: {
@@ -464,8 +464,9 @@ export default createStore({
 				//Check if user is following
 				if(state.params.features.showUserPronouns.value === true) {
 					if(uid && state.userPronouns[uid] == undefined && textMessage.tags.username) {
-						TwitchUtils.getPronouns(textMessage.tags.username).then((res:TwitchTypes.Pronoun) => {
-							state.userPronouns[uid] = res.pronoun_id;
+						TwitchUtils.getPronouns(uid, textMessage.tags.username).then((res: TwitchTypes.Pronoun | null) => {
+							if (res !== null)
+								state.userPronouns[uid] = res.pronoun_id;
 						}).catch(()=>{/*ignore*/})
 					}
 				}

--- a/src/utils/TwitchUtils.ts
+++ b/src/utils/TwitchUtils.ts
@@ -882,17 +882,40 @@ export default class TwitchUtils {
 	/**
 	 * Get pronouns of a user
 	 */
-	public static async getPronouns(username:string):Promise<TwitchTypes.Pronoun> {
-		const options = {
-			method:"GET",
+	public static async getPronouns(uid: string, username: string): Promise<TwitchTypes.Pronoun | null> {
+		const getPronounsAlejo = async (): Promise<TwitchTypes.Pronoun | null> => {
+			const res = await fetch(`https://pronouns.alejo.io/api/users/${username}`);
+			const data = await res.json();
+
+			if (data.error) {
+				throw data;
+			} else if (data.length > 0) {
+				return data[0];
+			}
+
+			return null;
 		};
-		const res = await fetch("https://pronouns.alejo.io/api/users/"+username, options);
-		const json = await res.json();
-		if(json.error) {
-			throw(json);
-		}else{
-			return json[0];
+
+		const getPronounsPronouDb = async (): Promise<TwitchTypes.Pronoun | null> => {
+			const res = await fetch(`https://pronoundb.org/api/v1/lookup?platform=twitch&id=${uid}`);
+			const data = await res.json();
+
+			if (data.pronouns === "unspecified")
+				return null;
+
+			return {
+				id: uid,
+				login: username,
+				pronoun_id: data.pronouns,
+			};
 		}
+
+		let pronoun = await getPronounsAlejo();
+		if (pronoun == null) {
+			pronoun = await getPronounsPronouDb();
+		}
+
+		return pronoun;
 	}
 }
 


### PR DESCRIPTION
Add support for [pronoundb.org](https://pronoundb.org/) as additionnal source for user's pronouns.
It works by basically fetching [pronouns.alejo.io](https://pronouns.alejo.io/) first then fetching [pronoundb.org](https://pronoundb.org/) if nothing is found, then returning `null` value is no entry could be found.

Also added a tooltip for the pronoun badge for [pronoundb.org](https://pronoundb.org/) specific cases which would requires a bit of additional context without making the badge overly large