### PR TITLE
Add an option to reverse activity feed entries

### DIFF
--- a/src/assets/icons/scrollUp_purple.svg
+++ b/src/assets/icons/scrollUp_purple.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 265.9 265.9" style="enable-background:new 0 0 265.9 265.9;" xml:space="preserve">
+<style type="text/css">
+	.st0{opacity:0.4;fill:#9147FF;}
+	.st1{fill:#9147FF;}
+</style>
+<path class="st0" d="M197,179.7l-52.1,79.7c-5.6,8.6-18.2,8.6-23.9,0l-52.1-79.7c-6.2-9.5,0.6-22.1,11.9-22.1l104.3,0
+	C196.4,157.7,203.2,170.3,197,179.7z"/>
+<path class="st1" d="M68.9,86.2L121,6.5c5.6-8.6,18.2-8.6,23.9,0L197,86.2c6.2,9.5-0.6,22.1-11.9,22.1l-104.3,0
+	C69.5,108.2,62.7,95.6,68.9,86.2z"/>
+</svg>

--- a/src/components/chatform/ActivityFeed.vue
+++ b/src/components/chatform/ActivityFeed.vue
@@ -9,9 +9,9 @@
 		<ActivityFeedFilters v-model="filters" class="filters" />
 		
 		<div
-        v-if="messages.length > 0"
-        class="messageList"
-        :class="{ 'messageListReverseOrder': $store.state.params.appearance.reverseActivityFeed.value }">
+				v-if="messages.length > 0"
+				class="messageList"
+				:class="{ 'messageListReverseOrder': $store.state.params.appearance.reverseActivityFeed.value }">
 			<div v-for="(m,index) in messages" :key="m.tags.id">
 				<ChatMessage
 					class="message"
@@ -308,10 +308,10 @@ export default class ActivityFeed extends Vue {
 			justify-self: flex-end;
 		}
 
-    .messageListReverseOrder {
-      display:flex;
-      flex-direction: column-reverse;
-    }
+		.messageListReverseOrder {
+			display:flex;
+			flex-direction: column-reverse;
+		}
 
 		.activityfeed {
 			width: 100%;

--- a/src/components/chatform/ActivityFeed.vue
+++ b/src/components/chatform/ActivityFeed.vue
@@ -1,73 +1,74 @@
 <template>
-	<div :class="classes">
-		<div class="head">
-			<h1 v-if="!listMode">Activity feed</h1>
-		</div>
+  <div :class="classes">
+    <div class="head">
+      <h1 v-if="!listMode">Activity feed</h1>
+    </div>
 
-		<div v-if="messages.length == 0" class="noActivity">- No activity yet -</div>
+    <div v-if="messages.length == 0" class="noActivity">- No activity yet -</div>
 
-		<ActivityFeedFilters v-model="filters" class="filters" />
-		
-		<div
-				v-if="messages.length > 0"
-				class="messageList"
-				:class="{ 'messageListReverseOrder': $store.state.params.appearance.reverseActivityFeed.value }">
-			<div v-for="(m,index) in messages" :key="m.tags.id">
-				<ChatMessage
-					class="message"
-					ref="message"
-					v-if="m.type == 'message'"
-					:messageData="m"
-					:data-index="index"
-					:lightMode="true" />
+    <ActivityFeedFilters v-model="filters" class="filters" />
 
-				<ChatHighlight
-					class="message"
-					ref="message"
-					v-if="m.type == 'highlight'"
-					:messageData="m"
-					:data-index="index"
-					:lightMode="true" />
+    <div
+        v-if="messages.length > 0"
+        class="messageList"
+        ref="messageList"
+        :class="{ 'messageListReverseOrder': $store.state.params.appearance.reverseActivityFeed.value }">
+      <div v-for="(m,index) in messages" :key="m.tags.id">
+        <ChatMessage
+          class="message"
+          ref="message"
+          v-if="m.type == 'message'"
+          :messageData="m"
+          :data-index="index"
+          :lightMode="true" />
 
-				<ChatPollResult
-					class="message"
-					ref="message"
-					v-else-if="m.type == 'poll'"
-					:pollData="m" />
+        <ChatHighlight
+          class="message"
+          ref="message"
+          v-if="m.type == 'highlight'"
+          :messageData="m"
+          :data-index="index"
+          :lightMode="true" />
 
-				<ChatPredictionResult
-					class="message"
-					ref="message"
-					v-else-if="m.type == 'prediction'"
-					:predictionData="m" />
+        <ChatPollResult
+          class="message"
+          ref="message"
+          v-else-if="m.type == 'poll'"
+          :pollData="m" />
 
-				<ChatNotice
-					class="message"
-					ref="message"
-					v-else-if="isCommercial(m)"
-					:messageData="m"
-					/>
+        <ChatPredictionResult
+          class="message"
+          ref="message"
+          v-else-if="m.type == 'prediction'"
+          :predictionData="m" />
 
-				<ChatBingoResult
-					class="message"
-					ref="message"
-					v-else-if="m.type == 'bingo'"
-					:bingoData="m" />
+        <ChatNotice
+          class="message"
+          ref="message"
+          v-else-if="isCommercial(m)"
+          :messageData="m"
+          />
 
-				<ChatRaffleResult
-					class="message"
-					ref="message"
-					v-else-if="m.type == 'raffle'"
-					:raffleData="m" />
+        <ChatBingoResult
+          class="message"
+          ref="message"
+          v-else-if="m.type == 'bingo'"
+          :bingoData="m" />
 
-				<ChatCountdownResult
-					class="message"
-					ref="message"
-					v-else-if="m.type == 'countdown'"
-					:countdownData="m" />
-			</div>
-		</div>
-	</div>
+        <ChatRaffleResult
+          class="message"
+          ref="message"
+          v-else-if="m.type == 'raffle'"
+          :raffleData="m" />
+
+        <ChatCountdownResult
+          class="message"
+          ref="message"
+          v-else-if="m.type == 'countdown'"
+          :countdownData="m" />
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -88,275 +89,310 @@ import ChatCountdownResult from '../messages/ChatCountdownResult.vue';
 import StoreProxy from '@/utils/StoreProxy';
 
 @Options({
-	props:{
-		listMode: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	components:{
-		ChatNotice,
-		ChatMessage,
-		ChatHighlight,
-		ChatPollResult,
-		ChatBingoResult,
-		ChatRaffleResult,
-		ChatCountdownResult,
-		ActivityFeedFilters,
-		ChatPredictionResult,
-	}
+  props:{
+    listMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  components:{
+    ChatNotice,
+    ChatMessage,
+    ChatHighlight,
+    ChatPollResult,
+    ChatBingoResult,
+    ChatRaffleResult,
+    ChatCountdownResult,
+    ActivityFeedFilters,
+    ChatPredictionResult,
+  }
 })
 export default class ActivityFeed extends Vue {
 
-	public listMode!:boolean;
+  public listMode!:boolean;
 
-	public filterKeys = "sub,follow,bits,raid,poll,prediction,bingo,raffle";
-	public filters:{[key:string]:boolean} = {};
-	
-	private clickHandler!:(e:MouseEvent) => void;
+  public filterKeys = "sub,follow,bits,raid,poll,prediction,bingo,raffle";
+  public filters:{[key:string]:boolean} = {};
 
-	public isCommercial(m:ActivityFeedData):boolean { return m.type == "notice" && m.tags['msg-id'] == 'commercial' }
+  private clickHandler!:(e:MouseEvent) => void;
 
-	public get classes():string[] {
-		const res = ["activityfeed"];
-		if(this.listMode === true) res.push("listMode");
-		return res;
-	}
-	
-	public get messages():ActivityFeedData[] {
-		const list = (StoreProxy.store.state.activityFeed as ActivityFeedData[])
-		.filter(v => v.type == "highlight"
-		|| v.type == "poll"
-		|| v.type == "prediction"
-		|| v.type == "bingo"
-		|| v.type == "raffle"
-		|| v.type == "countdown"
-		|| (v.type == "message" && v.tags["msg-id"] === "highlighted-message")
-		|| (v.type == "notice" && v.tags["msg-id"] === "commercial"));
+  public isCommercial(m:ActivityFeedData):boolean { return m.type == "notice" && m.tags['msg-id'] == 'commercial' }
 
-		const result:ActivityFeedData[] = [];
-		
-		const showSubs			= this.filters["sub"] === true || this.filters["sub"] === undefined;
-		const showFollow		= this.filters["follow"] === true || this.filters["follow"] === undefined;
-		const showBits			= this.filters["bits"] === true || this.filters["bits"] === undefined;
-		const showRaids			= this.filters["raid"] === true || this.filters["raid"] === undefined;
-		const showRewards		= this.filters["rewards"] === true || this.filters["rewards"] === undefined;
-		const showPolls			= this.filters["poll"] === true || this.filters["poll"] === undefined;
-		const showPredictions	= this.filters["prediction"] === true || this.filters["prediction"] === undefined;
-		const showBingos		= this.filters["bingo"] === true || this.filters["bingo"] === undefined;
-		const showRaffles		= this.filters["raffle"] === true || this.filters["raffle"] === undefined;
+  public get classes():string[] {
+    const res = ["activityfeed"];
+    if(this.listMode === true) res.push("listMode");
+    return res;
+  }
 
-		
-		for (let i = 0; i < list.length; i++) {
-			const m = list[i];
-			if(m.type == "message") {
-				result.unshift(m)
-				continue;
-			}
+  public get messages():ActivityFeedData[] {
+    const list = (StoreProxy.store.state.activityFeed as ActivityFeedData[])
+    .filter(v => v.type == "highlight"
+    || v.type == "poll"
+    || v.type == "prediction"
+    || v.type == "bingo"
+    || v.type == "raffle"
+    || v.type == "countdown"
+    || (v.type == "message" && v.tags["msg-id"] === "highlighted-message")
+    || (v.type == "notice" && v.tags["msg-id"] === "commercial"));
 
-			let type:"bits"|"sub"|"raid"|"reward"|"follow"|"poll"|"prediction"|"commercial"|"bingo"|"raffle"|"countdown"|null = null;
-			if(m.type == "poll") {
-				type = "poll";
-			}else if(m.type == "prediction") {
-				type = "prediction";
-			}else if(m.type == "bingo") {
-				type = "bingo";
-			}else if(m.type == "raffle") {
-				type = "raffle";
-			}else if(m.type == "countdown") {
-				type = "countdown";
-			}else if(m.type == "notice") {
-				if(m.tags['msg-id'] == "commercial") {
-					type = "commercial";
-				}
-			}else if(m.tags.bits) {
-				type = "bits";
-			}else if(m.methods?.prime) {
-				type = "sub";
-			}else if(m.methods?.plan) {
-				type = "sub";
-			}else if(m.recipient) {
-				type = "sub";
-			}else if(m.tags['message-type'] == "giftpaidupgrade") {
-				type = "sub";
-			}else if(m.reward) {
-				type = "reward";
-			}else if(m.tags['msg-id'] == "follow") {
-				type = "follow";
-			}else if(m.tags['msg-id'] == "raid") {
-				type = "raid";
-			}
-			
-			if(type == "sub" && showSubs) result.unshift(m);
-			if(type == "reward" && showRewards) result.unshift(m);
-			if(type == "raid" && showRaids) result.unshift(m);
-			if(type == "bits" && showBits) result.unshift(m);
-			if(type == "follow" && showFollow) result.unshift(m);
-			if(type == "poll" && showPolls) result.unshift(m);
-			if(type == "prediction" && showPredictions) result.unshift(m);
-			if(type == "bingo" && showBingos) result.unshift(m);
-			if(type == "raffle" && showRaffles) result.unshift(m);
-			if(type == "commercial") result.unshift(m);
-			if(type == "countdown") result.unshift(m);
-		}
-		
-		// if(this.listMode) {
-		// 	result.reverse();
-		// }
+    const result:ActivityFeedData[] = [];
 
-		return result;
-	}
+    const showSubs			= this.filters["sub"] === true || this.filters["sub"] === undefined;
+    const showFollow		= this.filters["follow"] === true || this.filters["follow"] === undefined;
+    const showBits			= this.filters["bits"] === true || this.filters["bits"] === undefined;
+    const showRaids			= this.filters["raid"] === true || this.filters["raid"] === undefined;
+    const showRewards		= this.filters["rewards"] === true || this.filters["rewards"] === undefined;
+    const showPolls			= this.filters["poll"] === true || this.filters["poll"] === undefined;
+    const showPredictions	= this.filters["prediction"] === true || this.filters["prediction"] === undefined;
+    const showBingos		= this.filters["bingo"] === true || this.filters["bingo"] === undefined;
+    const showRaffles		= this.filters["raffle"] === true || this.filters["raffle"] === undefined;
 
-	public beforeMount():void {
-		const f = Store.get(Store.ACTIVITY_FEED_FILTERS);
-		let json:{[key:string]:boolean} = {};
-		try {
-			json = JSON.parse(f);
-		}catch(e) {
-			if(typeof(f) == "string") {
-				//Migrate old data format:
-				//	"sub,follow,bits,..."
-				//To new format:
-				//	{sub:true, follow:false, bits:true}
-				const items = f.split(",");
-				for (let i = 0; i < items.length; i++) {
-					const key = items[i];
-					json[key] = true;
-				}
-				for (let i = 0; i < this.filterKeys.split(",").length; i++) {
-					const key = this.filterKeys.split(",")[i];
-					if(json[key] === undefined) json[key] = false;
-				}
-			}
-		}
-		if(f) this.filters = json;
-	}
 
-	public async mounted():Promise<void> {
+    for (let i = 0; i < list.length; i++) {
+      const m = list[i];
+      if(m.type == "message") {
+        result.unshift(m)
+        continue;
+      }
 
-		watch(()=>this.filters, ()=> {
-			Store.set(Store.ACTIVITY_FEED_FILTERS, this.filters);
-		});
+      let type:"bits"|"sub"|"raid"|"reward"|"follow"|"poll"|"prediction"|"commercial"|"bingo"|"raffle"|"countdown"|null = null;
+      if(m.type == "poll") {
+        type = "poll";
+      }else if(m.type == "prediction") {
+        type = "prediction";
+      }else if(m.type == "bingo") {
+        type = "bingo";
+      }else if(m.type == "raffle") {
+        type = "raffle";
+      }else if(m.type == "countdown") {
+        type = "countdown";
+      }else if(m.type == "notice") {
+        if(m.tags['msg-id'] == "commercial") {
+          type = "commercial";
+        }
+      }else if(m.tags.bits) {
+        type = "bits";
+      }else if(m.methods?.prime) {
+        type = "sub";
+      }else if(m.methods?.plan) {
+        type = "sub";
+      }else if(m.recipient) {
+        type = "sub";
+      }else if(m.tags['message-type'] == "giftpaidupgrade") {
+        type = "sub";
+      }else if(m.reward) {
+        type = "reward";
+      }else if(m.tags['msg-id'] == "follow") {
+        type = "follow";
+      }else if(m.tags['msg-id'] == "raid") {
+        type = "raid";
+      }
+
+      if(type == "sub" && showSubs) result.unshift(m);
+      if(type == "reward" && showRewards) result.unshift(m);
+      if(type == "raid" && showRaids) result.unshift(m);
+      if(type == "bits" && showBits) result.unshift(m);
+      if(type == "follow" && showFollow) result.unshift(m);
+      if(type == "poll" && showPolls) result.unshift(m);
+      if(type == "prediction" && showPredictions) result.unshift(m);
+      if(type == "bingo" && showBingos) result.unshift(m);
+      if(type == "raffle" && showRaffles) result.unshift(m);
+      if(type == "commercial") result.unshift(m);
+      if(type == "countdown") result.unshift(m);
+    }
+
+    this.onMessageAdded();
+
+    return result;
+  }
+
+  public beforeMount():void {
+    const f = Store.get(Store.ACTIVITY_FEED_FILTERS);
+    let json:{[key:string]:boolean} = {};
+    try {
+      json = JSON.parse(f);
+    }catch(e) {
+      if(typeof(f) == "string") {
+        //Migrate old data format:
+        //	"sub,follow,bits,..."
+        //To new format:
+        //	{sub:true, follow:false, bits:true}
+        const items = f.split(",");
+        for (let i = 0; i < items.length; i++) {
+          const key = items[i];
+          json[key] = true;
+        }
+        for (let i = 0; i < this.filterKeys.split(",").length; i++) {
+          const key = this.filterKeys.split(",")[i];
+          if(json[key] === undefined) json[key] = false;
+        }
+      }
+    }
+    if(f) this.filters = json;
+  }
+
+  public async mounted():Promise<void> {
+
+    watch(()=>this.filters, ()=> {
+      Store.set(Store.ACTIVITY_FEED_FILTERS, this.filters);
+    });
+
+    await this.$nextTick();
+    if(!this.listMode) {
+      this.clickHandler = (e:MouseEvent) => this.onClick(e);
+      document.addEventListener("mousedown", this.clickHandler);
+      this.open();
+    }
+  }
+
+  public beforeUnmount():void {
+    if(!this.listMode) {
+      document.removeEventListener("mousedown", this.clickHandler);
+    }
+  }
+
+  private open():void {
+    const ref = this.$el as HTMLDivElement;
+    gsap.killTweensOf(ref);
+    gsap.from(ref, {duration:.2, scaleY:0, clearProps:"scaleY", ease:"back.out(5)"});
+  }
+
+  private close():void {
+    const ref = this.$el as HTMLDivElement;
+    gsap.killTweensOf(ref);
+    gsap.to(ref, {duration:.2, scaleY:0, clearProps:"scaleY, scaleX", ease:"back.in(5)", onComplete:() => {
+      this.$emit("close");
+    }});
+  }
+
+  private onClick(e:MouseEvent):void {
+    let target = e.target as HTMLDivElement;
+    const ref = this.$el as HTMLDivElement;
+    while(target != document.body && target != ref && target) {
+      target = target.parentElement as HTMLDivElement;
+    }
+    if(target != ref) {
+      this.close();
+    }
+  }
+
+  private async onMessageAdded(): Promise<void> {
+    const list = this.$refs.messageList ?? null as HTMLDivElement|null;
+    const treshold = 10;
+
+    if (list === null) {
+      return;
+    }
+
+    let isAtBottom: boolean = list.scrollTop >= (list.scrollHeight - list.offsetHeight) - treshold;
+
+    /*if (! isAtBottom) {
+			console.log("Is Not At Bottom")
+      return;
+    }*/
+
+		//  en gros "là où il est" (scrollTop) moins "là où y va" (scrollHeight - offsetHeight)
+		const previousScrollHeight = list.scrollHeight;
 
 		await this.$nextTick();
-		if(!this.listMode) {
-			this.clickHandler = (e:MouseEvent) => this.onClick(e);
-			document.addEventListener("mousedown", this.clickHandler);
-			this.open();
-		}
-	}
 
-	public beforeUnmount():void {
-		if(!this.listMode) {
-			document.removeEventListener("mousedown", this.clickHandler);
-		}
-	}
+		const animationDurationInSeconds = Math.min((list.scrollHeight - previousScrollHeight - list.scrollTop) / 300, 3); // 1 - list.scrollTop / list.scrollHeight (en mode normal)
+		const from = {
+			scrollTop: -(list.scrollHeight - previousScrollHeight - list.scrollTop),
+		};
 
-	private open():void {
-		const ref = this.$el as HTMLDivElement;
-		gsap.killTweensOf(ref);
-		gsap.from(ref, {duration:.2, scaleY:0, clearProps:"scaleY", ease:"back.out(5)"});
-	}
+		const to = {
+			scrollTop: 0, //list.scrollHeight - list.offsetHeight,
+			duration: animationDurationInSeconds,
+			ease: "sine.inOut",
+		};
 
-	private close():void {
-		const ref = this.$el as HTMLDivElement;
-		gsap.killTweensOf(ref);
-		gsap.to(ref, {duration:.2, scaleY:0, clearProps:"scaleY, scaleX", ease:"back.in(5)", onComplete:() => {
-			this.$emit("close");
-		}});
-	}
+    gsap.killTweensOf(list);
+		gsap.fromTo(list, from, to);
 
-	private onClick(e:MouseEvent):void {
-		let target = e.target as HTMLDivElement;
-		const ref = this.$el as HTMLDivElement;
-		while(target != document.body && target != ref && target) {
-			target = target.parentElement as HTMLDivElement;
-		}
-		if(target != ref) {
-			this.close();
-		}
-	}
+		console.log("ANIM:", from, animationDurationInSeconds);
+  }
 }
 </script>
 
 <style scoped lang="less">
 .activityfeed{
-	.window();
-	// width: min-content;
-	right: 0;
-	left: auto;
-	margin-left: auto;
-	transform-origin: bottom center;
-	position: relative;
+  .window();
+  // width: min-content;
+  right: 0;
+  left: auto;
+  margin-left: auto;
+  transform-origin: bottom center;
+  position: relative;
 
 
-	&.listMode {
-		background: none;
-		box-shadow: unset;
-		flex-grow: 1;
-		padding: 0;
+  &.listMode {
+    background: none;
+    box-shadow: unset;
+    flex-grow: 1;
+    padding: 0;
 
-		.head {
-			top: 5px;
-			right: 3px;
-		}
+    .head {
+      top: 5px;
+      right: 3px;
+    }
 
-		.messageList {
-			max-height: unset;
-			min-height: auto;
-			flex-grow: 1;
-			justify-self: flex-end;
-		}
+    .messageList {
+      max-height: unset;
+      min-height: auto;
+      flex-grow: 1;
+      justify-self: flex-end;
+    }
 
-		.messageListReverseOrder {
-			display:flex;
-			flex-direction: column-reverse;
-		}
+    .messageListReverseOrder {
+      display:flex;
+      flex-direction: column-reverse;
+    }
 
-		.activityfeed {
-			width: 100%;
-		}
-	}
+    .activityfeed {
+      width: 100%;
+    }
+  }
 
-	.head {
-		h1 {
-			color: @mainColor_light;
-			align-self: center;
-			text-align: center;
-			margin-bottom: 10px;
-		}
-	}
+  .head {
+    h1 {
+      color: @mainColor_light;
+      align-self: center;
+      text-align: center;
+      margin-bottom: 10px;
+    }
+  }
 
-	.filters {
-		position: absolute;
-		right: 0;
-		top: 0;
-	}
+  .filters {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
 
-	.noActivity {
-		font-style: italic;
-		color: @mainColor_light;
-		font-size: 12px;
-		text-align: center;
-		margin: 15px 0;
-		opacity: .5;
-	}
+  .noActivity {
+    font-style: italic;
+    color: @mainColor_light;
+    font-size: 12px;
+    text-align: center;
+    margin: 15px 0;
+    opacity: .5;
+  }
 
-	.messageList{
-		font-size: 12px;
-		max-height: 50vh;
-		min-height: 30px;
-		overflow-y: auto;
-		.message{
-			margin: .5em 0;
-			font-size: var(--messageSize);
+  .messageList{
+    font-size: 12px;
+    max-height: 50vh;
+    min-height: 30px;
+    overflow-y: auto;
+    .message{
+      margin: .5em 0;
+      font-size: var(--messageSize);
 
-			:deep(.time) {
-				color: fade(#ffffff, 75%);
-				margin-right: 5px;
-				vertical-align: middle;
-			}
-		}
-	}
+      :deep(.time) {
+        color: fade(#ffffff, 75%);
+        margin-right: 5px;
+        vertical-align: middle;
+      }
+    }
+  }
 }
 </style>

--- a/src/components/chatform/ActivityFeed.vue
+++ b/src/components/chatform/ActivityFeed.vue
@@ -8,7 +8,10 @@
 
 		<ActivityFeedFilters v-model="filters" class="filters" />
 		
-		<div  v-if="messages.length > 0" class="messageList">
+		<div
+        v-if="messages.length > 0"
+        class="messageList"
+        :class="{ 'messageListReverseOrder': $store.state.params.appearance.reverseActivityFeed.value }">
 			<div v-for="(m,index) in messages" :key="m.tags.id">
 				<ChatMessage
 					class="message"
@@ -304,6 +307,11 @@ export default class ActivityFeed extends Vue {
 			flex-grow: 1;
 			justify-self: flex-end;
 		}
+
+    .messageListReverseOrder {
+      display:flex;
+      flex-direction: column-reverse;
+    }
 
 		.activityfeed {
 			width: 100%;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -259,6 +259,7 @@ const store = createStore({
 				displayTime: 				{save:true, type:"toggle", value:false, label:"Display time", id:6, icon:"timeout_purple.svg"},
 				historySize: 				{save:true, type:"slider", value:150, label:"Max chat message count", min:50, max:500, step:50, id:8},
 				defaultSize: 				{save:true, type:"slider", value:2, label:"Default text size", min:1, max:7, step:1, id:12},
+				reverseActivityFeed: 		{save:true, type:"toggle", value:false, label:"Reverse activity feed (newest activities on bottom)", id:23, icon:"scrollUp_purple.svg"},
 			} as {[key:string]:ParameterData},
 			filters: {
 				showSelf: 					{save:true, type:"toggle", value:true, label:"Show my messages", id:100},


### PR DESCRIPTION
I added an option in `Parameters > Appearance` that allow to reverse the order of activities so that new activity will be added at the bottom, just like chat.

![New options](https://user-images.githubusercontent.com/4490551/180301825-33e0fe4f-6d20-4105-aa0d-0d59885881a9.png)

![image](https://user-images.githubusercontent.com/4490551/180303221-df82926b-9fa5-4a09-b480-9b0f7bae4ae0.png)

