### PR TITLE
Add dockerized production version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:lts-alpine as builder
+
+COPY . /src
+WORKDIR /src
+
+RUN set -ex \
+ && apk --no-cache add \
+      rsync \
+ && npm ci \
+ && npm run build \
+ && mkdir /opt/twitchat \
+ && rsync -a /src/server/ /opt/twitchat/ \
+ && rsync -a /src/dist/ /opt/twitchat/public/ \
+ && rsync -a /src/node_modules/ /opt/twitchat/node_modules/ \
+ && echo -n "prod" >/opt/twitchat/env.conf \
+ && mkdir -p \
+      /opt/twitchat/beta \
+      /opt/twitchat/credentials \
+      /opt/twitchat/donors \
+      /opt/twitchat/userData \
+ && chown 10001 \
+      /opt/twitchat/beta \
+      /opt/twitchat/credentials \
+      /opt/twitchat/donors \
+      /opt/twitchat/userData
+
+
+FROM node:lts-alpine
+
+COPY --from=builder /opt/twitchat /opt/twitchat
+WORKDIR /opt/twitchat
+
+VOLUME ["/opt/twitchat/credentials", "/opt/twitchat/beta", "/opt/twitchat/donors", "/opt/twitchat/userData"]
+USER 10001
+EXPOSE 3018/tcp
+
+ENTRYPOINT ["node"]
+CMD ["bootstrap.js"]
+

--- a/README.md
+++ b/README.md
@@ -241,6 +241,26 @@ Here is the expected file structure:\
 <br>
 <br>
 
+### Run application in Docker
+After building and before running make sure you've created a local folder named `credentials` and put the `credentials.json` documented above into that folder. The command below will persist the data stored by Twitchat into the local `data` folder:
+
+```bash
+# Build the Docker image from source
+docker build -t twitchat .
+
+# Run the container with a local config and persisted data
+docker run --rm -ti \
+  -p 3018:3018 \
+  -v ./credentials:/opt/twitchat/credentials:ro \
+  -v ./data/beta:/opt/twitchat/beta \
+  -v ./data/donors:/opt/twitchat/donors \
+  -v ./data/userData:/opt/twitchat/userData \
+  twitchat
+```
+<br>
+<br>
+<br>
+
 # Localization
 # Adding new language
 Just create a new folder under the `i18n` folder with the ISO 639-1 code of the language.\

--- a/src_labels/index.js
+++ b/src_labels/index.js
@@ -33,7 +33,7 @@ const files = getLabelFilesFrom(rootDir);
 const output = {};
 for(let i=0; i < files.length; i++) {
 	const f = files[i];
-	const keys = f.replace(/\\+/g, "\\").replace(rootDir, "").replace(/\.json$/gi, "").split("\\");
+	const keys = f.replace(rootDir, "").replace(/\.json$/gi, "").split(path.sep);
 	const lang = keys[0];
 	// keys.pop()
 	let json = {};


### PR DESCRIPTION
This PR adds a Dockerfile to generate Twitchat's production version into a Docker image following the build-instructions from the README file.

Alongside it modifies the language compiler to work on Windows as well as POSIX systems (Linux, MacOS) by using system-specific path separator constant.